### PR TITLE
GearManager Favorites and Loadout

### DIFF
--- a/GTFO-API/Patches/GearManager_Patches.cs
+++ b/GTFO-API/Patches/GearManager_Patches.cs
@@ -21,6 +21,13 @@ namespace GTFO.API.Patches
             return false;
         }
 
+        [HarmonyPatch(nameof(GearManager.SaveFavoritesData))]
+        [HarmonyPrefix]
+        public static bool SaveFavoritesData_Prefix()
+        {
+            return false;
+        }
+
         [HarmonyPatch(nameof(GearManager.LoadOfflineGearDatas))]
         [HarmonyPostfix]
         public static void LoadOfflineGearDatas_Postfix()

--- a/GTFO-API/Patches/GearManager_Patches.cs
+++ b/GTFO-API/Patches/GearManager_Patches.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using Gear;
+using HarmonyLib;
+
+namespace GTFO.API.Patches
+{
+    [HarmonyPatch(typeof(GearManager))]
+    internal class GearManager_Patches
+    {
+        [HarmonyPatch(nameof(GearManager.RegisterGearInSlotAsEquipped))]
+        [HarmonyPrefix]
+        public static bool RegisterGearInSlotAsEquipped_Prefix()
+        {
+            return false;
+        }
+
+        [HarmonyPatch(nameof(GearManager.RegisterBotGearInSlotAsEquipped))]
+        [HarmonyPrefix]
+        public static bool RegisterBotGearInSlotAsEquipped_Prefix()
+        {
+            return false;
+        }
+
+        [HarmonyPatch(nameof(GearManager.LoadOfflineGearDatas))]
+        [HarmonyPostfix]
+        public static void LoadOfflineGearDatas_Postfix()
+        {
+            //Force players to equip the defaults for the currently loaded mod
+            GearManager.FavoritesData = new GearFavoritesData();
+            GearManager.BotFavoritesData = new BotFavoritesData();
+        }
+    }
+}

--- a/GTFO-API/Patches/GearManager_Patches.cs
+++ b/GTFO-API/Patches/GearManager_Patches.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Gear;
+﻿using Gear;
 using HarmonyLib;
 
 namespace GTFO.API.Patches
@@ -8,6 +7,7 @@ namespace GTFO.API.Patches
     internal class GearManager_Patches
     {
         [HarmonyPatch(nameof(GearManager.RegisterGearInSlotAsEquipped))]
+        [HarmonyWrapSafe]
         [HarmonyPrefix]
         public static bool RegisterGearInSlotAsEquipped_Prefix()
         {
@@ -15,6 +15,7 @@ namespace GTFO.API.Patches
         }
 
         [HarmonyPatch(nameof(GearManager.RegisterBotGearInSlotAsEquipped))]
+        [HarmonyWrapSafe]
         [HarmonyPrefix]
         public static bool RegisterBotGearInSlotAsEquipped_Prefix()
         {
@@ -22,6 +23,7 @@ namespace GTFO.API.Patches
         }
 
         [HarmonyPatch(nameof(GearManager.SaveFavoritesData))]
+        [HarmonyWrapSafe]
         [HarmonyPrefix]
         public static bool SaveFavoritesData_Prefix()
         {
@@ -29,6 +31,7 @@ namespace GTFO.API.Patches
         }
 
         [HarmonyPatch(nameof(GearManager.LoadOfflineGearDatas))]
+        [HarmonyWrapSafe]
         [HarmonyPostfix]
         public static void LoadOfflineGearDatas_Postfix()
         {


### PR DESCRIPTION
Prevent saving favorites that would cause users to have to delete their favorites files to switch mods or move back to vanilla.
Force default loadouts for players and bots on startup.