### PR TITLE
Added CoroutineDispatcher / Added Basic LiveEdit Support

### DIFF
--- a/GTFO-API/EntryPoint.cs
+++ b/GTFO-API/EntryPoint.cs
@@ -22,6 +22,7 @@ namespace GTFO.API
 
             APILogger.Verbose("Core", "Registering Utilities Implementations");
             ClassInjector.RegisterTypeInIl2Cpp<ThreadDispatcher_Impl>();
+            ClassInjector.RegisterTypeInIl2Cpp<CoroutineDispatcher_Impl>();
 
             APILogger.Verbose("Core", "Applying Patches");
             m_Harmony = new Harmony("dev.gtfomodding.gtfo-api");

--- a/GTFO-API/Utilities/CoroutineDispatcher.cs
+++ b/GTFO-API/Utilities/CoroutineDispatcher.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GTFO.API.Utilities.Impl;
+
+namespace GTFO.API.Utilities
+{
+    /// <summary>
+    /// Utility class for dispatching Coroutine without making new monobehaviour
+    /// </summary>
+    public static class CoroutineDispatcher
+    {
+        /// <summary>
+        /// Start Coroutine (persistent between sessions)
+        /// </summary>
+        /// <param name="routine">Coroutine to Run</param>
+        public static void StartCoroutine(IEnumerator routine)
+        {
+            CoroutineDispatcher_Impl.Instance.RunCoroutine(routine);
+        }
+
+        /// <summary>
+        /// Start InLevel Coroutine that will be stopped automatically when you stop playing level
+        /// </summary>
+        /// <param name="routine">Coroutine to Run</param>
+        public static void StartInLevelCoroutine(IEnumerator routine)
+        {
+            CoroutineDispatcher_Impl.Instance.RunInLevelCoroutine(routine);
+        }
+    }
+}

--- a/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
+++ b/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BepInEx.IL2CPP.Utils;
+using Il2CppInterop.Runtime.Attributes;
+using UnityEngine;
+
+namespace GTFO.API.Utilities.Impl
+{
+    internal class CoroutineDispatcher_Impl : MonoBehaviour
+    {
+        public static CoroutineDispatcher_Impl Instance
+        {
+            get
+            {
+                if (s_Instance == null)
+                {
+                    CoroutineDispatcher_Impl existing = FindObjectOfType<CoroutineDispatcher_Impl>();
+                    if (existing != null) s_Instance = existing;
+                }
+                return s_Instance;
+            }
+        }
+
+        static CoroutineDispatcher_Impl()
+        {
+            AssetAPI.OnStartupAssetsLoaded += OnAssetsLoaded;
+        }
+
+        private static void OnAssetsLoaded()
+        {
+            if (s_Instance != null) return;
+
+            GameObject dispatcher = new();
+            CoroutineDispatcher_Impl dispatcherComp = dispatcher.AddComponent<CoroutineDispatcher_Impl>();
+            dispatcher.name = "GTFO-API Coroutine Dispatcher";
+            dispatcher.hideFlags = HideFlags.HideAndDontSave;
+            GameObject.DontDestroyOnLoad(dispatcher);
+
+            s_Instance = dispatcherComp;
+        }
+
+        private void Update()
+        {
+            if (m_HasInLevelCoroutines && !GameStateManager.IsInExpedition)
+            {
+                m_InLevelCoroutines.ForEach((coroutine) => { StopCoroutine(coroutine); });
+            }
+        }
+
+        internal void RunCoroutine(IEnumerator routine)
+        {
+            this.StartCoroutine(routine);
+        }
+
+        internal void RunInLevelCoroutine(IEnumerator routine)
+        {
+            if (!GameStateManager.IsInExpedition)
+            {
+                APILogger.Error(nameof(CoroutineDispatcher), "Cannot run InLevelCoroutine while you're not in level!");
+                return;
+            }
+
+            var coroutine = this.StartCoroutine(routine);
+            m_InLevelCoroutines.Add(coroutine);
+            m_HasInLevelCoroutines = true;
+        }
+
+        private bool m_HasInLevelCoroutines = false;
+        private readonly List<Coroutine> m_InLevelCoroutines = null;
+        private static CoroutineDispatcher_Impl s_Instance = null;
+    }
+}

--- a/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
+++ b/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
@@ -52,11 +52,13 @@ namespace GTFO.API.Utilities.Impl
             }
         }
 
+        [HideFromIl2Cpp]
         internal void RunCoroutine(IEnumerator routine)
         {
             this.StartCoroutine(routine);
         }
 
+        [HideFromIl2Cpp]
         internal void RunInLevelCoroutine(IEnumerator routine)
         {
             if (!GameStateManager.IsInExpedition)

--- a/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
+++ b/GTFO-API/Utilities/Impl/CoroutineDispatcher_Impl.cs
@@ -48,6 +48,7 @@ namespace GTFO.API.Utilities.Impl
             if (m_HasInLevelCoroutines && !GameStateManager.IsInExpedition)
             {
                 m_InLevelCoroutines.ForEach((coroutine) => { StopCoroutine(coroutine); });
+                m_HasInLevelCoroutines = false;
             }
         }
 

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -111,7 +111,6 @@ namespace GTFO.API.Utilities
             }
 
             m_Watcher = null;
-            m_Allocated = false;
         }
 
         /// <summary>

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -29,11 +29,7 @@ namespace GTFO.API.Utilities
         /// <param name="includeSubDir">Include Sub-directories?</param>
         public static LiveEditListener CreateListener(string path, string filter, bool includeSubDir)
         {
-            LiveEditListener listener = new(path, filter, includeSubDir)
-            {
-                m_Allocated = true
-            };
-
+            LiveEditListener listener = new(path, filter, includeSubDir);
             s_Listeners.Add(listener);
             return listener;
         }
@@ -62,8 +58,8 @@ namespace GTFO.API.Utilities
         /// </summary>
         public event LiveEditEventHandler FileRenamed;
 
-        internal FileSystemWatcher m_Watcher = null;
-        internal bool m_Allocated = false;
+        private FileSystemWatcher m_Watcher = null;
+        private bool m_Allocated = true;
 
         private LiveEditListener() { }
 

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTFO.API.Utilities
+{
+    /// <summary>
+    /// LiveEditEventHandler
+    /// </summary>
+    /// <param name="e">EventArgs</param>
+    public delegate void LiveEditEventHandler(FileSystemEventArgs e);
+
+    /// <summary>
+    /// Utility class to make support of LiveEdit config file for plugins
+    /// </summary>
+    public static class LiveEdit
+    {
+        private static readonly List<LiveEditListener> m_Listeners = new ();
+
+        /// <summary>
+        /// Create the LiveEdit Listener and Allocate
+        /// </summary>
+        /// <param name="path">Base Path to Track the change</param>
+        /// <param name="filter">File filter to filter the files ie) *.json</param>
+        /// <param name="includeSubDir">Include Sub-directories?</param>
+        public static void CreateListener(string path, string filter, bool includeSubDir)
+        {
+            var listener = new LiveEditListener(path, filter, includeSubDir);
+            m_Listeners.Add(listener);
+        }
+
+        /// <summary>
+        /// Deallocate the LiveEdit Listener
+        /// </summary>
+        /// <param name="listener">Listener to deallocate</param>
+        public static void DeallocateListener(LiveEditListener listener)
+        {
+            if (listener == null)
+            {
+                APILogger.Error("LiveEdit", "DeallocateListener - listener was null!");
+                return;
+            }
+
+            if (listener.m_Watcher == null)
+            {
+                APILogger.Error("LiveEdit", "DeallocateListener - listener was already deallocated!");
+                return;
+            }
+
+            m_Listeners.Remove(listener);
+            listener.Deallocate();
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    [SuppressMessage("Interoperability", "CA1416:Platform Compatible on FileSystemWatcher", Justification = "GTFO is Windows only game")]
+    public sealed class LiveEditListener
+    {
+        /// <summary>
+        /// Event when File has Changed
+        /// </summary>
+        public event LiveEditEventHandler FileChanged;
+        /// <summary>
+        /// Event when File has Deleted
+        /// </summary>
+        public event LiveEditEventHandler FileDeleted;
+        /// <summary>
+        /// Event when File has Created
+        /// </summary>
+        public event LiveEditEventHandler FileCreated;
+        /// <summary>
+        /// Event when File has Renamed
+        /// </summary>
+        public event LiveEditEventHandler FileRenamed;
+
+        internal FileSystemWatcher m_Watcher = null;
+
+        private LiveEditListener() { }
+
+        internal LiveEditListener(string path, string filter, bool includeSubDir)
+        {
+            m_Watcher = new ()
+            {
+                Path = path,
+                Filter = filter,
+                IncludeSubdirectories = includeSubDir,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+            };
+
+            m_Watcher.Changed += (sender, e) => { FileChanged?.Invoke(e); };
+            m_Watcher.Deleted += (sender, e) => { FileDeleted?.Invoke(e); };
+            m_Watcher.Created += (sender, e) => { FileCreated?.Invoke(e); };
+            m_Watcher.Renamed += (sender, e) => { FileRenamed?.Invoke(e); };
+            m_Watcher.Error += (sender, e) =>
+            {
+                APILogger.Error("LiveEdit", $"Path: {path} error reported! - {e.GetException()}");
+            };
+        }
+
+        internal void Deallocate()
+        {
+            m_Watcher.EnableRaisingEvents = false;
+            FileChanged = null;
+            FileDeleted = null;
+            FileCreated = null;
+            FileRenamed = null;
+            m_Watcher.Dispose();
+            m_Watcher = null;
+        }
+
+        /// <summary>
+        /// Stop Listening LiveEdit
+        /// </summary>
+        public void StopListen()
+        {
+            if (m_Watcher != null)
+            {
+                m_Watcher.EnableRaisingEvents = false;
+            }
+        }
+
+        /// <summary>
+        /// Start Listening LiveEdit (Default On LiveEdit Allocated)
+        /// </summary>
+        public void StartListen()
+        {
+            if (m_Watcher != null)
+            {
+                m_Watcher.EnableRaisingEvents = true;
+            }
+        }
+    }
+}

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -27,10 +27,11 @@ namespace GTFO.API.Utilities
         /// <param name="path">Base Path to Track the change</param>
         /// <param name="filter">File filter to filter the files ie) *.json</param>
         /// <param name="includeSubDir">Include Sub-directories?</param>
-        public static void CreateListener(string path, string filter, bool includeSubDir)
+        public static LiveEditListener CreateListener(string path, string filter, bool includeSubDir)
         {
             var listener = new LiveEditListener(path, filter, includeSubDir);
             m_Listeners.Add(listener);
+            return listener;
         }
 
         /// <summary>
@@ -101,10 +102,13 @@ namespace GTFO.API.Utilities
             {
                 APILogger.Error("LiveEdit", $"Path: {path} error reported! - {e.GetException()}");
             };
+
+            StartListen();
         }
 
         internal void Deallocate()
         {
+            StopListen();
             m_Watcher.EnableRaisingEvents = false;
             FileChanged = null;
             FileDeleted = null;

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -19,7 +19,7 @@ namespace GTFO.API.Utilities
     /// </summary>
     public static class LiveEdit
     {
-        private static readonly List<LiveEditListener> s_Listeners = new();
+        internal static readonly List<LiveEditListener> s_Listeners = new();
 
         /// <summary>
         /// Create the LiveEdit Listener and Allocate
@@ -36,28 +36,6 @@ namespace GTFO.API.Utilities
 
             s_Listeners.Add(listener);
             return listener;
-        }
-
-        /// <summary>
-        /// Deallocate the LiveEdit Listener
-        /// </summary>
-        /// <param name="listener">Listener to deallocate</param>
-        public static void DeallocateListener(LiveEditListener listener)
-        {
-            if (listener == null)
-            {
-                APILogger.Error(nameof(LiveEdit), "DeallocateListener - listener was null!");
-                return;
-            }
-
-            if (!listener.m_Allocated)
-            {
-                APILogger.Error(nameof(LiveEdit), "DeallocateListener - listener was already deallocated!");
-                return;
-            }
-
-            s_Listeners.Remove(listener);
-            listener.Dispose();
         }
     }
 
@@ -118,7 +96,8 @@ namespace GTFO.API.Utilities
         {
             if (m_Allocated)
             {
-                LiveEdit.DeallocateListener(this);
+                LiveEdit.s_Listeners.Remove(this);
+                m_Allocated = false;
             }
             
             if (m_Watcher != null)


### PR DESCRIPTION
`CoroutineDispatcher` open up the API for opening persist Coroutine (or level session specific Coroutine) without making dummy type in every plugin

`LiveEdit` is Simplified use of FileSystemWatcher also without manually handle platform warning by each plugins