### PR TITLE
Added Free-Sized NetworkAPI

### DIFF
--- a/GTFO-API/API/Impl/EventInfos/FreeSizedNetworkingEventInfo.cs
+++ b/GTFO-API/API/Impl/EventInfos/FreeSizedNetworkingEventInfo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTFO.API.Impl
+{
+    internal sealed class FreeSizedNetworkingEventInfo : INetworkingEventInfo
+    {
+        public string Name { get; set; }
+        public Action<ulong, byte[]> OnReceive { get; set; }
+        public Type EventType => null;
+        public int EventTypeSize => INetworkingEventInfo.FreeByteSize;
+        public byte[] EventNameBytes { get; set; }
+
+        public void InvokeOnReceive(ulong sender, object payload)
+        {
+            if (payload is byte[] castedPayload)
+            {
+                OnReceive?.Invoke(sender, castedPayload);
+            }
+        }
+    }
+}

--- a/GTFO-API/API/Impl/EventInfos/INetworkingEventInfo.cs
+++ b/GTFO-API/API/Impl/EventInfos/INetworkingEventInfo.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTFO.API.Impl
+{
+    internal interface INetworkingEventInfo
+    {
+        string Name { get; }
+        Type EventType { get; }
+        int EventTypeSize { get; }
+        byte[] EventNameBytes { get; }
+        void InvokeOnReceive(ulong sender, object payload);
+
+        public bool IsFreeSized()
+        {
+            return EventTypeSize == FreeByteSize;
+        }
+
+        public const int FreeByteSize = -1;
+    }
+}

--- a/GTFO-API/API/Impl/EventInfos/NetworkingEventInfo.cs
+++ b/GTFO-API/API/Impl/EventInfos/NetworkingEventInfo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTFO.API.Impl
+{
+    internal sealed class NetworkingEventInfo<T> : INetworkingEventInfo where T : struct
+    {
+        public string Name { get; set; }
+        public Action<ulong, T> OnReceive { get; set; }
+        public Type EventType { get; set; }
+        public int EventTypeSize { get; set; }
+        public byte[] EventNameBytes { get; set; }
+
+        public void InvokeOnReceive(ulong sender, object payload)
+        {
+            if (payload is T castedPayload)
+            {
+                OnReceive?.Invoke(sender, castedPayload);
+            }
+        }
+    }
+}

--- a/GTFO-API/API/Impl/NetworkAPI_Impl.FixedSize.cs
+++ b/GTFO-API/API/Impl/NetworkAPI_Impl.FixedSize.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Il2CppInterop.Runtime.Attributes;
+using GTFO.API.Resources;
+using UnityEngine;
+
+namespace GTFO.API.Impl
+{
+    internal sealed partial class NetworkAPI_Impl : MonoBehaviour
+    {
+        [HideFromIl2Cpp]
+        public void RegisterEvent<T>(string eventName, Action<ulong, T> onReceive) where T : struct
+        {
+            if (EventExists(eventName))
+            {
+                throw new ArgumentException($"Type {typeof(T)} is a generic and cannot be registered.", nameof(eventName));
+            }
+
+            if (typeof(T).IsGenericType)
+            {
+                throw new ArgumentException($"Generic type is not allowed to register", nameof(T));
+            }
+
+            NetworkingEventInfo<T> eventInfo = new()
+            {
+                Name = eventName,
+                OnReceive = onReceive,
+                EventType = typeof(T),
+                EventTypeSize = Marshal.SizeOf<T>(),
+                EventNameBytes = Encoding.UTF8.GetBytes(eventName)
+            };
+
+            m_Events.Add(eventName, eventInfo);
+        }
+
+        [HideFromIl2Cpp]
+        public byte[] MakePacketBytes<T>(string eventName, T payload) where T : struct
+        {
+            if (!m_Events.TryGetValue(eventName, out INetworkingEventInfo info))
+            {
+                throw new ArgumentException($"An event with the name {eventName} was not registered.", nameof(eventName));
+            }
+
+            if (info.IsFreeSized())
+            {
+                throw new InvalidOperationException($"Event '{eventName}' is NOT registered as FixedSize Event!");
+            }
+
+            if (info.EventType != typeof(T))
+            {
+                throw new ArgumentException($"Payload type was incorrect! expecting: {typeof(T).FullName}", nameof(eventName));
+            }
+
+            byte[] eventNameBytes = info.EventNameBytes;
+            int size = 2 + NetworkConstants.MagicSize + 8 + 2 + eventNameBytes.Length + info.EventTypeSize;
+            IntPtr pPacketBase = Marshal.AllocHGlobal(size);
+
+            IntPtr pPacket = pPacketBase;
+
+            Marshal.WriteInt16(pPacket, (short)m_ReplicatorKey);
+            pPacket += 2;
+
+            Marshal.Copy(s_MagicBytes, 0, pPacket, NetworkConstants.MagicSize);
+            pPacket += NetworkConstants.MagicSize;
+
+            Marshal.WriteInt64(pPacket, (long)m_Signature);
+            pPacket += 8;
+
+            Marshal.WriteInt16(pPacket, (short)eventNameBytes.Length);
+            pPacket += 2;
+
+            Marshal.Copy(eventNameBytes, 0, pPacket, eventNameBytes.Length);
+            pPacket += eventNameBytes.Length;
+
+            Marshal.StructureToPtr(payload, pPacket, true);
+
+            byte[] packetBytes = new byte[size];
+            Marshal.Copy(pPacketBase, packetBytes, 0, size);
+
+            Marshal.FreeHGlobal(pPacketBase);
+
+            XORPacket(ref packetBytes, m_Signature, 2 + NetworkConstants.MagicSize + 8 + 2 + eventNameBytes.Length);
+            return packetBytes;
+        }
+    }
+}

--- a/GTFO-API/API/Impl/NetworkAPI_Impl.FreeSize.cs
+++ b/GTFO-API/API/Impl/NetworkAPI_Impl.FreeSize.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Il2CppInterop.Runtime.Attributes;
+using GTFO.API.Resources;
+using UnityEngine;
+using System.Runtime.InteropServices;
+
+namespace GTFO.API.Impl
+{
+    internal sealed partial class NetworkAPI_Impl : MonoBehaviour
+    {
+        [HideFromIl2Cpp]
+        public void RegisterFreeSizedEvent(string eventName, Action<ulong, byte[]> onReceive)
+        {
+            if (EventExists(eventName))
+            {
+                throw new ArgumentException($"EventName '{eventName}' is already registered!", nameof(eventName));
+            }
+
+            FreeSizedNetworkingEventInfo eventInfo = new()
+            {
+                Name = eventName,
+                OnReceive = onReceive,
+                EventNameBytes = Encoding.UTF8.GetBytes(eventName)
+            };
+
+            m_Events.Add(eventName, eventInfo);
+        }
+
+        [HideFromIl2Cpp]
+        public byte[] MakeFreeSizedPacketBytes(string eventName, byte[] payload)
+        {
+            if (!m_Events.TryGetValue(eventName, out INetworkingEventInfo info))
+            {
+                throw new ArgumentException($"An event with the name {eventName} was not registered.", nameof(eventName));
+            }
+
+            if (!info.IsFreeSized())
+            {
+                throw new InvalidOperationException($"Event '{eventName}' is NOT registered as FreeSized Event!");
+            }
+
+            if (payload == null)
+            {
+                throw new ArgumentNullException(nameof(payload), $"Payload was null!");
+            }
+
+            if (payload.Length <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(payload), $"Payload was Empty!");
+            }
+
+            byte[] eventNameBytes = info.EventNameBytes;
+            int nameBytesLength = eventNameBytes.Length;
+            int payloadLength = payload.Length;
+            int size = 2 + NetworkConstants.MagicSize + 8 + 2 + nameBytesLength + payloadLength;
+            IntPtr pPacketBase = Marshal.AllocHGlobal(size);
+
+            IntPtr pPacket = pPacketBase;
+
+            //Write Packet Bytes
+            Marshal.WriteInt16(pPacket, (short)m_ReplicatorKey);
+            pPacket += 2;
+
+            Marshal.Copy(s_MagicBytes, 0, pPacket, NetworkConstants.MagicSize);
+            pPacket += NetworkConstants.MagicSize;
+
+            Marshal.WriteInt64(pPacket, (long)m_Signature);
+            pPacket += 8;
+
+            Marshal.WriteInt16(pPacket, (short)nameBytesLength);
+            pPacket += 2;
+
+            Marshal.Copy(eventNameBytes, 0, pPacket, nameBytesLength);
+            pPacket += nameBytesLength;
+
+            Marshal.Copy(payload, 0, pPacket, payloadLength);
+            //
+
+            byte[] packetBytes = new byte[size];
+            Marshal.Copy(pPacketBase, packetBytes, 0, size);
+            Marshal.FreeHGlobal(pPacketBase);
+
+            XORPacket(ref packetBytes, m_Signature, 2 + NetworkConstants.MagicSize + 8 + 2 + eventNameBytes.Length);
+            return packetBytes;
+        }
+    }
+}


### PR DESCRIPTION
### Description
This change add new API inside NetworkAPI
```cs
NetworkAPI.RegisterFreeSizedEvent(string eventName, Action<ulong, byte[]> onReceiveBytes);
NetworkAPI.InvokeFreeSizedEvent(string eventName, byte[] payload, SNet_ChannelType channelType = SNet_ChannelType.GameOrderCritical);
NetworkAPI.InvokeFreeSizedEvent(string eventName, byte[] payload, SNet_Player target, SNet_ChannelType channelType = SNet_ChannelType.GameOrderCritical);
NetworkAPI.InvokeFreeSizedEvent(string eventName, byte[] payload, IEnumerable<SNet_Player> targets, SNet_ChannelType channelType = SNet_ChannelType.GameOrderCritical);
```

### Why This change is needed
FreeSized byte array packet event type work as workaround for below problems
 - Handle the case where generic is inside the struct (Marshalling struct with generic using `Marshal` is not supported)
 - Able to easily resize the packet size or usage. No longer forced to register multiple event with different payload struct. or each usage