### PR TITLE
Async Bundle Loading and API to block base game's loading process

### DIFF
--- a/GTFO-API/API/AssetAPI.AssetLoadHandle.cs
+++ b/GTFO-API/API/AssetAPI.AssetLoadHandle.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTFO.API.API
+{
+    /// <summary>
+    /// Handle that allocated when you called <see cref="AssetAPI.WantToWorkForStartupAssets"/>
+    /// This blocks game loading until every allocated AssetLoadHandle as marked as completed
+    /// </summary>
+    public sealed class AssetLoadHandle
+    {
+        /// <summary>
+        /// true if current load job has ended
+        /// </summary>
+        public bool IsCompleted { get; private set; }
+
+        /// <summary>
+        /// Mark this specific Asset loading job as completed
+        /// </summary>
+        public void SetCompleted()
+        {
+            IsCompleted = true;
+        }
+
+        /// <summary>
+        /// Add Line to loading text 
+        /// </summary>
+        public void AddLoadingText(string text)
+        {
+            MainMenuGuiLayer.Current.PageIntro.m_textCenter.AddLine($"<size=35%>{text}</size>");
+        }
+    }
+}

--- a/GTFO-API/API/Impl/AssetAPI_Impl.cs
+++ b/GTFO-API/API/Impl/AssetAPI_Impl.cs
@@ -1,6 +1,12 @@
 ﻿using System;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
 using AssetShards;
+using BepInEx.Unity.IL2CPP.Utils;
+using GTFO.API.API;
 using GTFO.API.Resources;
+using Il2CppInterop.Runtime.Attributes;
 using UnityEngine;
 
 namespace GTFO.API.Impl
@@ -21,6 +27,103 @@ namespace GTFO.API.Impl
                 return s_Instance;
             }
         }
+        
+        private int _LoadingCount = 0;
+
+        private readonly Stopwatch _SW = new();
+        private int _DebugLoadingCount;
+
+        private static readonly string COMPRESSED_STR = "-compressed";
+        private static readonly int COMPRESSED_STR_LENGTH = COMPRESSED_STR.Length;
+
+        [Conditional("DEBUG")]
+        [HideFromIl2Cpp]
+        public void DEBUG_BundleLoadingStarted(int loadingCount)
+        {
+            _SW.Restart();
+            _DebugLoadingCount = loadingCount;
+        }
+
+        [Conditional("DEBUG")]
+        [HideFromIl2Cpp]
+        public void DEBUG_BundleLoadingFinished()
+        {
+            _SW.Stop();
+            APILogger.Verbose($"Asset", $"Elapsed Time to loading {_DebugLoadingCount} bundles:");
+            APILogger.Verbose($"Asset", $" - {_SW.Elapsed}! (or {_SW.ElapsedMilliseconds}ms)");
+        }
+
+        [HideFromIl2Cpp]
+        public void LoadAssetBundle(string filePath, AssetLoadHandle loadHandle)
+        {
+            _LoadingCount++;
+            this.StartCoroutine(DoLoadAssetBundle(filePath, loadHandle));
+        }
+
+        [HideFromIl2Cpp]
+        private IEnumerator DoLoadAssetBundle(string filePath, AssetLoadHandle loadHandle)
+        {
+            AssetBundleCreateRequest loadReq = AssetBundle.LoadFromFileAsync(filePath);
+
+            yield return loadReq;
+
+            AssetBundle loadedBundle = loadReq.assetBundle;
+            if (loadedBundle == null)
+            {
+                _LoadingCount--;
+                APILogger.Warn($"Asset", $"Failed to load asset bundle: [{filePath}]");
+                yield break;
+            }
+
+
+            APILogger.Warn($"Asset", $"Start Loading Bundle!");
+            string[] assetNames = loadedBundle.AllAssetNames();
+            int remainingAssets = assetNames.Length;
+            int loadedCount = 0;
+
+            foreach (string assetName in assetNames)
+            {
+                AssetBundleRequest loadAssetReq = loadedBundle.LoadAssetAsync(assetName);
+                loadAssetReq.add_completed((Action<AsyncOperation>)((x) =>
+                {
+                    remainingAssets--;
+                    loadedCount++;
+
+                    UnityEngine.Object loadedAsset = loadAssetReq.asset;
+                    if (loadedAsset == null)
+                    {
+                        APILogger.Warn("Asset", $"Skipping asset {assetName}");
+                    }
+
+                    RegisterAsset(assetName, loadedAsset);
+                }));
+                yield return null;
+            }
+
+            yield return new WaitUntil((Il2CppSystem.Func<bool>)(() =>
+            {
+                return remainingAssets <= 0;
+            }));
+
+            _LoadingCount--;
+            loadHandle.SetCompleted();
+
+            string fileName = Path.GetFileNameWithoutExtension(filePath);
+            if (fileName.EndsWith(COMPRESSED_STR, StringComparison.InvariantCultureIgnoreCase))
+                fileName = fileName[^COMPRESSED_STR_LENGTH..]; //Trim "-Compressed" from bundle name
+
+            loadHandle.AddLoadingText($"[Assets] <color=orange>{fileName}</color> has loaded!");
+
+            if (_LoadingCount <= 0)
+            {
+                _LoadingCount = 0;
+                loadHandle.AddLoadingText($"[Assets] All bundle has loaded!");
+                AssetAPI.InvokeBundleLoaded();
+                DEBUG_BundleLoadingFinished();
+            }
+            
+            yield return null;
+        }
 
         private void Awake()
         {
@@ -34,6 +137,7 @@ namespace GTFO.API.Impl
             AssetAPI.InvokeImplReady();
         }
 
+        [HideFromIl2Cpp]
         public void RegisterAsset(string name, UnityEngine.Object gameObject)
         {
             string upperName = name.ToUpper();

--- a/GTFO-API/Patches/GS_Offline_Patches.cs
+++ b/GTFO-API/Patches/GS_Offline_Patches.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+
+namespace GTFO.API.Patches
+{
+    [HarmonyPatch(typeof(GS_Offline))]
+    internal class GS_Offline_Patches
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(GS_Offline.Update))]
+        static bool Prefix()
+        {
+            if (AssetAPI.IsReadyForStartup)
+            {
+                return true; //Run Original
+            }
+
+            return false; //Skip Original
+        }
+    }
+}


### PR DESCRIPTION
This PR allow GTFO-API to load bundles asynchronously and also adding loading screen to show players to what assets being loaded ATM

It would have some time-saving on loading multiple bundles even the unity's async asset loading is not fully working parallelly. (by saving little time loading file itself or listing assets)

Plus, this PR open new API in AssetAPI to plugin developers to load their stuff during loading screen asynchronously and print out process while loading

```cs
AssetAPI.OnCustomAssetsLoading += LoadAudios;

void LoadAudios()
{
  foreach (var file in files)
  {
    AssetAPI.WantToWorkForStartupAssets(out AssetLoadHandle loadingHandle);
    Task.Run(LoadAudioAsync(file, in loadingHandle));
  }
}

async Task LoadAudio(string file, in AssetLoadHandle loadingHandle)
{
  loadingHandle.AddLoadingText($"Start Loading Audio: {file}");
  //await Do Loading
  loadingHandle.AddLoadingText($"Loaded Audio: {file}");
  loadingHandle.SetCompleted();
}
```