### PR TITLE
Add SafeFileSystemWatcher

### DIFF
--- a/GTFO-API/EntryPoint.cs
+++ b/GTFO-API/EntryPoint.cs
@@ -23,6 +23,7 @@ namespace GTFO.API
             APILogger.Verbose("Core", "Registering Utilities Implementations");
             ClassInjector.RegisterTypeInIl2Cpp<ThreadDispatcher_Impl>();
             ClassInjector.RegisterTypeInIl2Cpp<CoroutineDispatcher_Impl>();
+            ClassInjector.RegisterTypeInIl2Cpp<SafeFileSystemWatcherUpdater_Impl>();
 
             APILogger.Verbose("Core", "Applying Patches");
             m_Harmony = new Harmony("dev.gtfomodding.gtfo-api");

--- a/GTFO-API/Utilities/Impl/SafeFileSystemWatcherUpdater_Impl.cs
+++ b/GTFO-API/Utilities/Impl/SafeFileSystemWatcherUpdater_Impl.cs
@@ -48,10 +48,10 @@ internal sealed class SafeFileSystemWatcherUpdater_Impl : MonoBehaviour
 
     static SafeFileSystemWatcherUpdater_Impl()
     {
-        AssetAPI.OnStartupAssetsLoaded += OnAssetsLoaded;
+        EventAPI.OnManagersSetup += OnSetup;
     }
 
-    private static void OnAssetsLoaded()
+    private static void OnSetup()
     {
         if (s_Instance != null) return;
 

--- a/GTFO-API/Utilities/Impl/SafeFileSystemWatcherUpdater_Impl.cs
+++ b/GTFO-API/Utilities/Impl/SafeFileSystemWatcherUpdater_Impl.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace GTFO.API.Utilities.Impl;
+
+internal sealed class SafeFileSystemWatcherUpdater_Impl : MonoBehaviour
+{
+    private static readonly List<SafeFileSystemWatcher> s_WatchersToUpdate = [];
+
+    private static SafeFileSystemWatcherUpdater_Impl s_Instance = null;
+
+    public static SafeFileSystemWatcherUpdater_Impl Instance
+    {
+        get
+        {
+            if (s_Instance == null)
+            {
+                SafeFileSystemWatcherUpdater_Impl existing = FindObjectOfType<SafeFileSystemWatcherUpdater_Impl>();
+                if (existing != null) s_Instance = existing;
+            }
+            return s_Instance;
+        }
+    }
+
+    private void Update()
+    {
+        foreach (var watchers in s_WatchersToUpdate)
+        {
+            watchers.HandleEvents();
+        }
+    }
+
+    public static void AddWatcher(SafeFileSystemWatcher watcher)
+    {
+        lock (s_WatchersToUpdate)
+        {
+            s_WatchersToUpdate.Add(watcher);
+        }
+    }
+
+    public static void RemoveWatcher(SafeFileSystemWatcher watcher)
+    {
+        lock (s_WatchersToUpdate)
+        {
+            s_WatchersToUpdate.Remove(watcher);
+        }
+    }
+
+    static SafeFileSystemWatcherUpdater_Impl()
+    {
+        AssetAPI.OnStartupAssetsLoaded += OnAssetsLoaded;
+    }
+
+    private static void OnAssetsLoaded()
+    {
+        if (s_Instance != null) return;
+
+        GameObject dispatcher = new();
+        SafeFileSystemWatcherUpdater_Impl updaterComp = dispatcher.AddComponent<SafeFileSystemWatcherUpdater_Impl>();
+        dispatcher.name = "GTFO-API SafeFileSystemWatcher Updater";
+        dispatcher.hideFlags = HideFlags.HideAndDontSave;
+        GameObject.DontDestroyOnLoad(dispatcher);
+
+        s_Instance = updaterComp;
+    }
+}

--- a/GTFO-API/Utilities/LiveEdit.cs
+++ b/GTFO-API/Utilities/LiveEdit.cs
@@ -3,9 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace GTFO.API.Utilities
@@ -63,6 +61,7 @@ namespace GTFO.API.Utilities
     /// <summary>
     /// Utility class to make support of LiveEdit config file for plugins
     /// </summary>
+    [Obsolete($"{nameof(SafeFileSystemWatcher)} Can Cover a Usage of LiveEdit")]
     public static class LiveEdit
     {
         internal const int RETRY_COUNT = 5;
@@ -107,7 +106,7 @@ namespace GTFO.API.Utilities
             retryInterval = Math.Max(retryInterval, 0.0f);
 
             var wait = new WaitForSecondsRealtime(retryInterval);
-            for(int i = 0; i < retryCount; i++)
+            for (int i = 0; i < retryCount; i++)
             {
                 try
                 {
@@ -126,6 +125,7 @@ namespace GTFO.API.Utilities
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete($"{nameof(SafeFileSystemWatcher)} Can Cover a Usage of LiveEdit")]
     [SuppressMessage("Interoperability", "CA1416:Platform Compatible on FileSystemWatcher", Justification = "GTFO is Windows only game")]
     public sealed class LiveEditListener : IDisposable
     {
@@ -159,7 +159,7 @@ namespace GTFO.API.Utilities
 
         internal LiveEditListener(string path, string filter, bool includeSubDir)
         {
-            m_Watcher = new ()
+            m_Watcher = new()
             {
                 Path = path,
                 Filter = filter,
@@ -167,7 +167,7 @@ namespace GTFO.API.Utilities
                 NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
             };
 
-            
+
             m_Watcher.Deleted += (sender, e) => { ThreadDispatcher.Dispatch(() => { FileDeleted?.Invoke(CreateArgs(e, LiveEditEventType.Deleted)); }); };
             m_Watcher.Created += (sender, e) => { ThreadDispatcher.Dispatch(() => { FileCreated?.Invoke(CreateArgs(e, LiveEditEventType.Created)); }); };
             m_Watcher.Renamed += (sender, e) => { ThreadDispatcher.Dispatch(() => { FileRenamed?.Invoke(CreateArgs(e, LiveEditEventType.Renamed)); }); };
@@ -212,7 +212,7 @@ namespace GTFO.API.Utilities
                 LiveEdit.s_Listeners.Remove(this);
                 m_Allocated = false;
             }
-            
+
             if (m_Watcher != null)
             {
                 StopListen();

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.EventArgs.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.EventArgs.cs
@@ -1,0 +1,103 @@
+﻿using System.IO;
+using System.Text;
+
+namespace GTFO.API.Utilities;
+
+/// <summary>
+/// Type of File Event
+/// </summary>
+public enum FileEventType
+{
+    /// <summary>
+    /// File has created
+    /// </summary>
+    Created,
+    /// <summary>
+    /// File has deleted
+    /// </summary>
+    Deleted,
+    /// <summary>
+    /// File has renamed
+    /// </summary>
+    Renamed,
+    /// <summary>
+    /// File has changed
+    /// </summary>
+    Changed
+}
+
+/// <summary>
+/// SafeFileSystemWatcher Event Arguments
+/// </summary>
+public record FileEventArgs
+{
+    /// <summary>
+    /// Triggered Event Type
+    /// </summary>
+    public FileEventType Type { get; init; }
+
+    /// <summary>
+    /// Full Path to File
+    /// </summary>
+    public string FullPath { get; init; }
+
+    /// <summary>
+    /// Name of the File (Does not include path)
+    /// </summary>
+    public string FileName { get; init; }
+
+    /// <summary>
+    /// Read Text Content of the Target File
+    /// </summary>
+    /// <param name="encoding">Encoding to use. <see cref="Encoding.Default"/> If <see langword="null"/></param>
+    /// <returns>Full Text Content of the File</returns>
+    public string ReadContent(Encoding encoding = null)
+    {
+        using FileStream fs = OpenReadStream();
+        using StreamReader sr = new StreamReader(fs, encoding ?? Encoding.Default);
+        return sr.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Open a Read-Only FileStream of the Target File
+    /// </summary>
+    /// <returns>Opened FileStream</returns>
+    public FileStream OpenReadStream()
+    {
+        return new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+    }
+
+    /// <summary>
+    /// Check If Target File is Locked by other Process
+    /// </summary>
+    /// <returns>true if it's locked</returns>
+    public bool IsFileLocked()
+    {
+        try
+        {
+            using FileStream fs = new FileStream(FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+}
+
+/// <summary>
+/// SafeFileSystemWatcher Event Arguments
+/// </summary>
+public sealed record FileRenamedEventArgs : FileEventArgs
+{
+    /// <summary>
+    /// Full Path to Old File<br/>
+    /// </summary>
+    public string OldFullPath { get; init; }
+
+    /// <summary>
+    /// Name of the Old File<br/>
+    /// </summary>
+    public string OldFileName { get; init; }
+}
+

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -283,40 +283,37 @@ namespace GTFO.API.Utilities
 
         internal void HandleEvents()
         {
-            lock (_QueuedEvents)
+            if (_QueuedEvents.IsEmpty)
+                return;
+
+            _HandledEventInFrame.Clear();
+            while (_QueuedEvents.TryDequeue(out var arg))
             {
-                if (_QueuedEvents.IsEmpty)
-                    return;
-
-                _HandledEventInFrame.Clear();
-                while (_QueuedEvents.TryDequeue(out var arg))
+                if (_HandledEventInFrame.Contains(arg))
                 {
-                    if (_HandledEventInFrame.Contains(arg))
-                    {
-                        continue;
-                    }
-
-                    if (RetryOnLocked && (arg.Type != FileEventType.Deleted && arg.IsFileLocked()))
-                    {
-                        _RetryQueue.Enqueue(arg);
-                        continue;
-                    }
-
-                    switch (arg.Type)
-                    {
-                        case FileEventType.Created: OnCreated?.Invoke(arg); break;
-                        case FileEventType.Deleted: OnDeleted?.Invoke(arg); break;
-                        case FileEventType.Renamed: OnRenamed?.Invoke((FileRenamedEventArgs)arg); break;
-                        case FileEventType.Changed: OnChanged?.Invoke(arg); break;
-                    }
-
-                    _HandledEventInFrame.Add(arg);
+                    continue;
                 }
 
-                while (_RetryQueue.TryDequeue(out var arg))
+                if (RetryOnLocked && (arg.Type != FileEventType.Deleted && arg.IsFileLocked()))
                 {
-                    _QueuedEvents.Enqueue(arg);
+                    _RetryQueue.Enqueue(arg);
+                    continue;
                 }
+
+                switch (arg.Type)
+                {
+                    case FileEventType.Created: OnCreated?.Invoke(arg); break;
+                    case FileEventType.Deleted: OnDeleted?.Invoke(arg); break;
+                    case FileEventType.Renamed: OnRenamed?.Invoke((FileRenamedEventArgs)arg); break;
+                    case FileEventType.Changed: OnChanged?.Invoke(arg); break;
+                }
+
+                _HandledEventInFrame.Add(arg);
+            }
+
+            while (_RetryQueue.TryDequeue(out var arg))
+            {
+                _QueuedEvents.Enqueue(arg);
             }
         }
 

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -3,345 +3,245 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Text;
 using BepInEx.Configuration;
 using GTFO.API.Utilities.Impl;
 
-namespace GTFO.API.Utilities
+namespace GTFO.API.Utilities;
+
+/// <summary>
+/// Wrapper of FileSystemWatcher Which Features:
+/// <list>
+/// - Ensuring Events Invocation Thread to be Unity's Main Thread<br/>
+/// - Debounces Multiple Invocation for Single Action<br/>
+/// - Ensure the File Lock Safety
+/// </list>
+/// </summary>
+public sealed class SafeFileSystemWatcher : IDisposable
 {
-    /// <summary>
-    /// Type of File Event
-    /// </summary>
-    public enum FileEventType
+    /// <inheritdoc cref="FileSystemWatcher.Filters"/>
+    public Collection<string> Filters => _Watcher.Filters;
+
+    /// <inheritdoc cref="FileSystemWatcher.Filter"/>
+    public string Filter
     {
-        /// <summary>
-        /// File has created
-        /// </summary>
-        Created,
-        /// <summary>
-        /// File has deleted
-        /// </summary>
-        Deleted,
-        /// <summary>
-        /// File has renamed
-        /// </summary>
-        Renamed,
-        /// <summary>
-        /// File has changed
-        /// </summary>
-        Changed
+        get => _Watcher.Filter;
+        set => _Watcher.Filter = value;
+    }
+
+    /// <inheritdoc cref="FileSystemWatcher.Path"/>
+    public string Path
+    {
+        get => _Watcher.Path;
+        set => _Watcher.Path = value;
     }
 
     /// <summary>
-    /// SafeFileSystemWatcher Event Arguments
+    /// Gets or sets the type of changes to watch for.
+    /// <br/>
+    /// - Default: <see cref="NotifyFilters.FileName"/> | <see cref="NotifyFilters.LastWrite"/> | <see cref="NotifyFilters.CreationTime"/>
     /// </summary>
-    public record FileEventArgs
+    public NotifyFilters NotifyFilter
     {
-        /// <summary>
-        /// Triggered Event Type
-        /// </summary>
-        public FileEventType Type { get; init; }
+        get => _Watcher.NotifyFilter;
+        set => _Watcher.NotifyFilter = value;
+    }
 
-        /// <summary>
-        /// Full Path to File
-        /// </summary>
-        public string FullPath { get; init; }
-
-        /// <summary>
-        /// Name of the File (Does not include path)
-        /// </summary>
-        public string FileName { get; init; }
-
-        /// <summary>
-        /// Read Text Content of the Target File
-        /// </summary>
-        /// <param name="encoding">Encoding to use. <see cref="Encoding.Default"/> If <see langword="null"/></param>
-        /// <returns>Full Text Content of the File</returns>
-        public string ReadContent(Encoding encoding = null)
-        {
-            using FileStream fs = OpenReadStream();
-            using StreamReader sr = new StreamReader(fs, encoding ?? Encoding.Default);
-            return sr.ReadToEnd();
-        }
-
-        /// <summary>
-        /// Open a Read-Only FileStream of the Target File
-        /// </summary>
-        /// <returns>Opened FileStream</returns>
-        public FileStream OpenReadStream()
-        {
-            return new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        }
-
-        /// <summary>
-        /// Check If Target File is Locked by other Process
-        /// </summary>
-        /// <returns>true if it's locked</returns>
-        public bool IsFileLocked()
-        {
-            try
-            {
-                using FileStream fs = new FileStream(FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-                return false;
-            }
-            catch
-            {
-                return true;
-            }
-        }
+    /// <inheritdoc cref="FileSystemWatcher.IncludeSubdirectories"/>
+    public bool IncludeSubDir
+    {
+        get => _Watcher.IncludeSubdirectories;
+        set => _Watcher.IncludeSubdirectories = value;
     }
 
     /// <summary>
-    /// SafeFileSystemWatcher Event Arguments
+    /// Should FileSystemWatcher Listen to Events?
     /// </summary>
-    public sealed record FileRenamedEventArgs : FileEventArgs
+    public bool Listening
     {
-        /// <summary>
-        /// Full Path to Old File<br/>
-        /// </summary>
-        public string OldFullPath { get; init; }
-
-        /// <summary>
-        /// Name of the Old File<br/>
-        /// </summary>
-        public string OldFileName { get; init; }
+        get => _Watcher.EnableRaisingEvents;
+        set => _Watcher.EnableRaisingEvents = value;
     }
 
     /// <summary>
-    /// Wrapper of FileSystemWatcher Which Features:
-    /// <list>
-    /// - Ensuring Events Invocation Thread to be Unity's Main Thread<br/>
-    /// - Debounces Multiple Invocation for Single Action<br/>
-    /// - Ensure the File Lock Safety
-    /// </list>
+    /// Should Event be Re-Queued when file is locked?<br/>
+    /// - Default: <see langword="true"/>
     /// </summary>
-    public sealed class SafeFileSystemWatcher : IDisposable
+    public bool RetryOnLocked { get; set; } = true;
+
+    /// <summary>
+    /// Event when File has Changed
+    /// </summary>
+    public event Action<FileEventArgs> OnChanged;
+
+    /// <summary>
+    /// Event when File has Created
+    /// </summary>
+    public event Action<FileEventArgs> OnCreated;
+
+    /// <summary>
+    /// Event when File has Deleted
+    /// </summary>
+    public event Action<FileEventArgs> OnDeleted;
+
+    /// <summary>
+    /// Event when File has Renamed
+    /// </summary>
+    public event Action<FileRenamedEventArgs> OnRenamed;
+
+    private readonly FileSystemWatcher _Watcher = new();
+    private readonly ConcurrentQueue<FileEventArgs> _QueuedEvents = [];
+    private readonly HashSet<FileEventArgs> _HandledEventInFrame = [];
+    private readonly Queue<FileEventArgs> _RetryQueue = [];
+
+    private bool _DisposedValue;
+
+    private SafeFileSystemWatcher() { }
+
+    /// <summary>
+    /// Create <see cref="SafeFileSystemWatcher"/> Instance
+    /// </summary>
+    /// <param name="path">Path to Watch</param>
+    /// <param name="filters">List of Filter to Use</param>
+    /// <param name="includeSubDir"></param>
+    /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
+    public static SafeFileSystemWatcher Create(string path, string[] filters = null, bool includeSubDir = false)
     {
-        /// <inheritdoc cref="FileSystemWatcher.Filters"/>
-        public Collection<string> Filters => _Watcher.Filters;
-
-        /// <inheritdoc cref="FileSystemWatcher.Filter"/>
-        public string Filter
+        var sfsw = new SafeFileSystemWatcher
         {
-            get => _Watcher.Filter;
-            set => _Watcher.Filter = value;
-        }
+            Path = path,
+            IncludeSubDir = includeSubDir,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+        };
 
-        /// <inheritdoc cref="FileSystemWatcher.Path"/>
-        public string Path
+        if (filters != null && filters.Length > 0)
         {
-            get => _Watcher.Path;
-            set => _Watcher.Path = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the type of changes to watch for.
-        /// <br/>
-        /// - Default: <see cref="NotifyFilters.FileName"/> | <see cref="NotifyFilters.LastWrite"/> | <see cref="NotifyFilters.CreationTime"/>
-        /// </summary>
-        public NotifyFilters NotifyFilter
-        {
-            get => _Watcher.NotifyFilter;
-            set => _Watcher.NotifyFilter = value;
-        }
-
-        /// <inheritdoc cref="FileSystemWatcher.IncludeSubdirectories"/>
-        public bool IncludeSubDir
-        {
-            get => _Watcher.IncludeSubdirectories;
-            set => _Watcher.IncludeSubdirectories = value;
-        }
-
-        /// <summary>
-        /// Should FileSystemWatcher Listen to Events?
-        /// </summary>
-        public bool Listening
-        {
-            get => _Watcher.EnableRaisingEvents;
-            set => _Watcher.EnableRaisingEvents = value;
-        }
-
-        /// <summary>
-        /// Should Event be Re-Queued when file is locked?<br/>
-        /// - Default: <see langword="true"/>
-        /// </summary>
-        public bool RetryOnLocked { get; set; } = true;
-
-        /// <summary>
-        /// Event when File has Changed
-        /// </summary>
-        public event Action<FileEventArgs> OnChanged;
-
-        /// <summary>
-        /// Event when File has Created
-        /// </summary>
-        public event Action<FileEventArgs> OnCreated;
-
-        /// <summary>
-        /// Event when File has Deleted
-        /// </summary>
-        public event Action<FileEventArgs> OnDeleted;
-
-        /// <summary>
-        /// Event when File has Renamed
-        /// </summary>
-        public event Action<FileRenamedEventArgs> OnRenamed;
-
-        private readonly FileSystemWatcher _Watcher = new();
-        private readonly ConcurrentQueue<FileEventArgs> _QueuedEvents = [];
-        private readonly HashSet<FileEventArgs> _HandledEventInFrame = [];
-        private readonly Queue<FileEventArgs> _RetryQueue = [];
-
-        private bool _DisposedValue;
-
-        private SafeFileSystemWatcher() { }
-
-        /// <summary>
-        /// Create <see cref="SafeFileSystemWatcher"/> Instance
-        /// </summary>
-        /// <param name="path">Path to Watch</param>
-        /// <param name="filters">List of Filter to Use</param>
-        /// <param name="includeSubDir"></param>
-        /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
-        public static SafeFileSystemWatcher Create(string path, string[] filters = null, bool includeSubDir = false)
-        {
-            var sfsw = new SafeFileSystemWatcher
+            sfsw.Filters.Clear();
+            foreach (var filter in filters)
             {
-                Path = path,
-                IncludeSubDir = includeSubDir,
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
-            };
-
-            if (filters != null && filters.Length > 0)
-            {
-                sfsw.Filters.Clear();
-                foreach (var filter in filters)
-                {
-                    sfsw.Filters.Add(filter);
-                }
-            }
-
-            sfsw._Watcher.Created += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Created, e);
-            sfsw._Watcher.Deleted += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Deleted, e);
-            sfsw._Watcher.Changed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Changed, e);
-            sfsw._Watcher.Renamed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Renamed, e);
-            sfsw._Watcher.Error += (sender, e) =>
-            {
-                APILogger.Error(nameof(SafeFileSystemWatcher), $"Path: '{path}' error was reported! - {e.GetException()}");
-            };
-
-            sfsw.Listening = true;
-            APILogger.Verbose(nameof(SafeFileSystemWatcher), $"Created Watcher; Path: '{path}', Filter: {string.Join(", ", filters)}");
-            SafeFileSystemWatcherUpdater_Impl.AddWatcher(sfsw);
-            return sfsw;
-        }
-
-        /// <summary>
-        /// Create <see cref="SafeFileSystemWatcher"/> Instance From a <see cref="ConfigFile"/> and Automatically Reloads Config upon Change<br/>
-        ///  - Events are recommended to be handled by '<see cref="ConfigFile.ConfigReloaded"/>' or '<see cref="ConfigEntry{T}.SettingChanged"/>'
-        /// </summary>
-        /// <param name="configFile">Config to Watch</param>
-        /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
-        public static SafeFileSystemWatcher Create(ConfigFile configFile)
-        {
-            var fullPath = configFile.ConfigFilePath;
-            var fileName = System.IO.Path.GetFileName(fullPath);
-            var pathName = System.IO.Path.GetDirectoryName(fullPath);
-            var sfsw = Create(pathName, [fileName], false);
-            sfsw.OnChanged += (e) =>
-            {
-                configFile.Reload();
-            };
-
-            return sfsw;
-        }
-
-        private void EnqueueEventArg(FileEventType type, FileSystemEventArgs arg)
-        {
-            if (type == FileEventType.Renamed)
-            {
-                var renamed = (RenamedEventArgs)arg;
-                _QueuedEvents.Enqueue(new FileRenamedEventArgs()
-                {
-                    Type = type,
-                    FullPath = renamed.FullPath,
-                    FileName = System.IO.Path.GetFileName(renamed.FullPath),
-                    OldFullPath = renamed.OldFullPath,
-                    OldFileName = System.IO.Path.GetFileName(renamed.OldFullPath)
-                });
-            }
-            else
-            {
-                _QueuedEvents.Enqueue(new()
-                {
-                    Type = type,
-                    FullPath = arg.FullPath,
-                    FileName = System.IO.Path.GetFileName(arg.FullPath),
-                });
+                sfsw.Filters.Add(filter);
             }
         }
 
-        internal void HandleEvents()
+        sfsw._Watcher.Created += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Created, e);
+        sfsw._Watcher.Deleted += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Deleted, e);
+        sfsw._Watcher.Changed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Changed, e);
+        sfsw._Watcher.Renamed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Renamed, e);
+        sfsw._Watcher.Error += (sender, e) =>
         {
-            if (_QueuedEvents.IsEmpty)
-                return;
+            APILogger.Error(nameof(SafeFileSystemWatcher), $"Path: '{path}' error was reported! - {e.GetException()}");
+        };
 
-            _HandledEventInFrame.Clear();
-            while (_QueuedEvents.TryDequeue(out var arg))
+        sfsw.Listening = true;
+        APILogger.Verbose(nameof(SafeFileSystemWatcher), $"Created Watcher; Path: '{path}', Filter: {string.Join(", ", filters)}");
+        SafeFileSystemWatcherUpdater_Impl.AddWatcher(sfsw);
+        return sfsw;
+    }
+
+    /// <summary>
+    /// Create <see cref="SafeFileSystemWatcher"/> Instance From a <see cref="ConfigFile"/> and Automatically Reloads Config upon Change<br/>
+    ///  - Events are recommended to be handled by '<see cref="ConfigFile.ConfigReloaded"/>' or '<see cref="ConfigEntry{T}.SettingChanged"/>'
+    /// </summary>
+    /// <param name="configFile">Config to Watch</param>
+    /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
+    public static SafeFileSystemWatcher Create(ConfigFile configFile)
+    {
+        var fullPath = configFile.ConfigFilePath;
+        var fileName = System.IO.Path.GetFileName(fullPath);
+        var pathName = System.IO.Path.GetDirectoryName(fullPath);
+        var sfsw = Create(pathName, [fileName], false);
+        sfsw.OnChanged += (e) =>
+        {
+            configFile.Reload();
+        };
+
+        return sfsw;
+    }
+
+    private void EnqueueEventArg(FileEventType type, FileSystemEventArgs arg)
+    {
+        if (type == FileEventType.Renamed)
+        {
+            var renamed = (RenamedEventArgs)arg;
+            _QueuedEvents.Enqueue(new FileRenamedEventArgs()
             {
-                if (_HandledEventInFrame.Contains(arg))
-                {
-                    continue;
-                }
+                Type = type,
+                FullPath = renamed.FullPath,
+                FileName = System.IO.Path.GetFileName(renamed.FullPath),
+                OldFullPath = renamed.OldFullPath,
+                OldFileName = System.IO.Path.GetFileName(renamed.OldFullPath)
+            });
+        }
+        else
+        {
+            _QueuedEvents.Enqueue(new()
+            {
+                Type = type,
+                FullPath = arg.FullPath,
+                FileName = System.IO.Path.GetFileName(arg.FullPath),
+            });
+        }
+    }
 
-                if (RetryOnLocked && (arg.Type != FileEventType.Deleted && arg.IsFileLocked()))
-                {
-                    _RetryQueue.Enqueue(arg);
-                    continue;
-                }
+    internal void HandleEvents()
+    {
+        if (_QueuedEvents.IsEmpty)
+            return;
 
-                switch (arg.Type)
-                {
-                    case FileEventType.Created: OnCreated?.Invoke(arg); break;
-                    case FileEventType.Deleted: OnDeleted?.Invoke(arg); break;
-                    case FileEventType.Renamed: OnRenamed?.Invoke((FileRenamedEventArgs)arg); break;
-                    case FileEventType.Changed: OnChanged?.Invoke(arg); break;
-                }
-
-                _HandledEventInFrame.Add(arg);
+        _HandledEventInFrame.Clear();
+        while (_QueuedEvents.TryDequeue(out var arg))
+        {
+            if (_HandledEventInFrame.Contains(arg))
+            {
+                continue;
             }
 
-            while (_RetryQueue.TryDequeue(out var arg))
+            if (RetryOnLocked && (arg.Type != FileEventType.Deleted && arg.IsFileLocked()))
             {
-                _QueuedEvents.Enqueue(arg);
+                _RetryQueue.Enqueue(arg);
+                continue;
             }
-        }
 
-        private void Dispose(bool disposing)
-        {
-            if (!_DisposedValue)
+            switch (arg.Type)
             {
-                if (disposing)
-                {
-                    _Watcher.Dispose();
-                    OnCreated = null;
-                    OnDeleted = null;
-                    OnRenamed = null;
-                    OnChanged = null;
-
-                    _QueuedEvents.Clear();
-                    _HandledEventInFrame.Clear();
-                    _RetryQueue.Clear();
-                    SafeFileSystemWatcherUpdater_Impl.RemoveWatcher(this);
-                }
-                _DisposedValue = true;
+                case FileEventType.Created: OnCreated?.Invoke(arg); break;
+                case FileEventType.Deleted: OnDeleted?.Invoke(arg); break;
+                case FileEventType.Renamed: OnRenamed?.Invoke((FileRenamedEventArgs)arg); break;
+                case FileEventType.Changed: OnChanged?.Invoke(arg); break;
             }
+
+            _HandledEventInFrame.Add(arg);
         }
 
-        public void Dispose()
+        while (_RetryQueue.TryDequeue(out var arg))
         {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            _QueuedEvents.Enqueue(arg);
         }
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!_DisposedValue)
+        {
+            if (disposing)
+            {
+                _Watcher.Dispose();
+                OnCreated = null;
+                OnDeleted = null;
+                OnRenamed = null;
+                OnChanged = null;
+
+                _QueuedEvents.Clear();
+                _HandledEventInFrame.Clear();
+                _RetryQueue.Clear();
+                SafeFileSystemWatcherUpdater_Impl.RemoveWatcher(this);
+            }
+            _DisposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -285,7 +285,7 @@ namespace GTFO.API.Utilities
         {
             lock (_QueuedEvents)
             {
-                if (_QueuedEvents.Count <= 0)
+                if (_QueuedEvents.IsEmpty)
                     return;
 
                 _HandledEventInFrame.Clear();

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -108,7 +108,12 @@ namespace GTFO.API.Utilities
     }
 
     /// <summary>
-    /// Wrapper of FileSystemWatcher; Handle threading issue and debouncing of FSW's multiple invokes
+    /// Wrapper of FileSystemWatcher Which Features:
+    /// <list>
+    /// - Ensuring Events Invocation Thread to be Unity's Main Thread<br/>
+    /// - Debounces Multiple Invocation for Single Action<br/>
+    /// - Ensure the File Lock Safety
+    /// </list>
     /// </summary>
     public sealed class SafeFileSystemWatcher : IDisposable
     {
@@ -132,7 +137,7 @@ namespace GTFO.API.Utilities
         /// <summary>
         /// Gets or sets the type of changes to watch for.
         /// <br/>
-        /// - Default: NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+        /// - Default: <see cref="NotifyFilters.FileName"/> | <see cref="NotifyFilters.LastWrite"/> | <see cref="NotifyFilters.CreationTime"/>
         /// </summary>
         public NotifyFilters NotifyFilter
         {
@@ -157,27 +162,28 @@ namespace GTFO.API.Utilities
         }
 
         /// <summary>
-        /// Should Event be Re-Queued when file is locked?
+        /// Should Event be Re-Queued when file is locked?<br/>
+        /// - Default: <see langword="true"/>
         /// </summary>
         public bool RetryOnLocked { get; set; } = true;
 
         /// <summary>
-        /// Event when File has Changed, Thread-safe
+        /// Event when File has Changed
         /// </summary>
         public event Action<FileEventArgs> OnChanged;
 
         /// <summary>
-        /// Event when File has Created, Thread-safe
+        /// Event when File has Created
         /// </summary>
         public event Action<FileEventArgs> OnCreated;
 
         /// <summary>
-        /// Event when File has Deleted, Thread-safe
+        /// Event when File has Deleted
         /// </summary>
         public event Action<FileEventArgs> OnDeleted;
 
         /// <summary>
-        /// Event when File has Renamed, Thread-safe
+        /// Event when File has Renamed
         /// </summary>
         public event Action<FileRenamedEventArgs> OnRenamed;
 

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using BepInEx.Configuration;
+using GTFO.API.Utilities.Impl;
+
+namespace GTFO.API.Utilities
+{
+    /// <summary>
+    /// Type of File Event
+    /// </summary>
+    public enum FileEventType
+    {
+        /// <summary>
+        /// File has created
+        /// </summary>
+        Created,
+        /// <summary>
+        /// File has deleted
+        /// </summary>
+        Deleted,
+        /// <summary>
+        /// File has renamed
+        /// </summary>
+        Renamed,
+        /// <summary>
+        /// File has changed
+        /// </summary>
+        Changed
+    }
+
+    /// <summary>
+    /// SafeFileSystemWatcher Event Arguments
+    /// </summary>
+    public record FileEventArgs
+    {
+        /// <summary>
+        /// Triggered Event Type
+        /// </summary>
+        public FileEventType Type { get; init; }
+
+        /// <summary>
+        /// Full Path to File
+        /// </summary>
+        public string FullPath { get; init; }
+
+        /// <summary>
+        /// Name of the File (Does not include path)
+        /// </summary>
+        public string FileName { get; init; }
+
+        /// <summary>
+        /// Read Text Content of the Target File
+        /// </summary>
+        /// <param name="encoding">Encoding to use. <see cref="Encoding.Default"/> If <see langword="null"/></param>
+        /// <returns>Full Text Content of the File</returns>
+        public string ReadContent(Encoding encoding = null)
+        {
+            using FileStream fs = OpenReadStream();
+            using StreamReader sr = new StreamReader(fs, encoding ?? Encoding.Default);
+            return sr.ReadToEnd();
+        }
+
+        /// <summary>
+        /// Open a Read-Only FileStream of the Target File
+        /// </summary>
+        /// <returns>Opened FileStream</returns>
+        public FileStream OpenReadStream()
+        {
+            return new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        }
+
+        /// <summary>
+        /// Check If Target File is Locked by other Process
+        /// </summary>
+        /// <returns>true if it's locked</returns>
+        public bool IsFileLocked()
+        {
+            try
+            {
+                using FileStream fs = new FileStream(FullPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                return false;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// SafeFileSystemWatcher Event Arguments
+    /// </summary>
+    public sealed record FileRenamedEventArgs : FileEventArgs
+    {
+        /// <summary>
+        /// Full Path to Old File<br/>
+        /// </summary>
+        public string OldFullPath { get; init; }
+
+        /// <summary>
+        /// Name of the Old File<br/>
+        /// </summary>
+        public string OldFileName { get; init; }
+    }
+
+    /// <summary>
+    /// Wrapper of FileSystemWatcher; Handle threading issue and debouncing of FSW's multiple invokes
+    /// </summary>
+    public sealed class SafeFileSystemWatcher : IDisposable
+    {
+        /// <inheritdoc cref="FileSystemWatcher.Filters"/>
+        public Collection<string> Filters => _Watcher.Filters;
+
+        /// <inheritdoc cref="FileSystemWatcher.Filter"/>
+        public string Filter
+        {
+            get => _Watcher.Filter;
+            set => _Watcher.Filter = value;
+        }
+
+        /// <inheritdoc cref="FileSystemWatcher.Path"/>
+        public string Path
+        {
+            get => _Watcher.Path;
+            set => _Watcher.Path = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the type of changes to watch for.
+        /// <br/>
+        /// - Default: NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+        /// </summary>
+        public NotifyFilters NotifyFilter
+        {
+            get => _Watcher.NotifyFilter;
+            set => _Watcher.NotifyFilter = value;
+        }
+
+        /// <inheritdoc cref="FileSystemWatcher.IncludeSubdirectories"/>
+        public bool IncludeSubDir
+        {
+            get => _Watcher.IncludeSubdirectories;
+            set => _Watcher.IncludeSubdirectories = value;
+        }
+
+        /// <summary>
+        /// Should FileSystemWatcher Listen to Events?
+        /// </summary>
+        public bool Listening
+        {
+            get => _Watcher.EnableRaisingEvents;
+            set => _Watcher.EnableRaisingEvents = value;
+        }
+
+        /// <summary>
+        /// Should Event be Re-Queued when file is locked?
+        /// </summary>
+        public bool RetryOnLocked { get; set; } = true;
+
+        /// <summary>
+        /// Event when File has Changed, Thread-safe
+        /// </summary>
+        public event Action<FileEventArgs> OnChanged;
+
+        /// <summary>
+        /// Event when File has Created, Thread-safe
+        /// </summary>
+        public event Action<FileEventArgs> OnCreated;
+
+        /// <summary>
+        /// Event when File has Deleted, Thread-safe
+        /// </summary>
+        public event Action<FileEventArgs> OnDeleted;
+
+        /// <summary>
+        /// Event when File has Renamed, Thread-safe
+        /// </summary>
+        public event Action<FileRenamedEventArgs> OnRenamed;
+
+        private readonly FileSystemWatcher _Watcher = new();
+        private readonly ConcurrentQueue<FileEventArgs> _QueuedEvents = [];
+        private readonly HashSet<FileEventArgs> _HandledEventInFrame = [];
+        private readonly Queue<FileEventArgs> _RetryQueue = [];
+
+        private bool _DisposedValue;
+
+        private SafeFileSystemWatcher() { }
+
+        /// <summary>
+        /// Create <see cref="SafeFileSystemWatcher"/> Instance
+        /// </summary>
+        /// <param name="path">Path to Watch</param>
+        /// <param name="filters">List of Filter to Use</param>
+        /// <param name="includeSubDir"></param>
+        /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
+        public static SafeFileSystemWatcher Create(string path, string[] filters = null, bool includeSubDir = false)
+        {
+            var sfsw = new SafeFileSystemWatcher
+            {
+                Path = path,
+                IncludeSubDir = includeSubDir,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.CreationTime
+            };
+
+            if (filters != null && filters.Length > 0)
+            {
+                sfsw.Filters.Clear();
+                foreach (var filter in filters)
+                {
+                    sfsw.Filters.Add(filter);
+                }
+            }
+
+            sfsw._Watcher.Created += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Created, e);
+            sfsw._Watcher.Deleted += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Deleted, e);
+            sfsw._Watcher.Changed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Changed, e);
+            sfsw._Watcher.Renamed += (sender, e) => sfsw.EnqueueEventArg(FileEventType.Renamed, e);
+            sfsw._Watcher.Error += (sender, e) =>
+            {
+                APILogger.Error(nameof(SafeFileSystemWatcher), $"Path: '{path}' error was reported! - {e.GetException()}");
+            };
+
+            sfsw.Listening = true;
+            APILogger.Verbose(nameof(SafeFileSystemWatcher), $"Created Watcher; Path: '{path}', Filter: {string.Join(", ", filters)}");
+            SafeFileSystemWatcherUpdater_Impl.AddWatcher(sfsw);
+            return sfsw;
+        }
+
+        /// <summary>
+        /// Create <see cref="SafeFileSystemWatcher"/> Instance From a <see cref="ConfigFile"/> and Automatically Reloads Config upon Change<br/>
+        ///  - Events are recommended to be handled by '<see cref="ConfigFile.ConfigReloaded"/>' or '<see cref="ConfigEntry{T}.SettingChanged"/>'
+        /// </summary>
+        /// <param name="configFile">Config to Watch</param>
+        /// <returns>New <see cref="SafeFileSystemWatcher"/> Instance with given setting</returns>
+        public static SafeFileSystemWatcher Create(ConfigFile configFile)
+        {
+            var fullPath = configFile.ConfigFilePath;
+            var fileName = System.IO.Path.GetFileName(fullPath);
+            var pathName = System.IO.Path.GetDirectoryName(fullPath);
+            var sfsw = Create(pathName, [fileName], false);
+            sfsw.OnChanged += (e) =>
+            {
+                configFile.Reload();
+            };
+
+            return sfsw;
+        }
+
+        private void EnqueueEventArg(FileEventType type, FileSystemEventArgs arg)
+        {
+            if (type == FileEventType.Renamed)
+            {
+                var renamed = (RenamedEventArgs)arg;
+                _QueuedEvents.Enqueue(new FileRenamedEventArgs()
+                {
+                    Type = type,
+                    FullPath = renamed.FullPath,
+                    FileName = System.IO.Path.GetFileName(renamed.FullPath),
+                    OldFullPath = renamed.OldFullPath,
+                    OldFileName = System.IO.Path.GetFileName(renamed.OldFullPath)
+                });
+            }
+            else
+            {
+                _QueuedEvents.Enqueue(new()
+                {
+                    Type = type,
+                    FullPath = arg.FullPath,
+                    FileName = System.IO.Path.GetFileName(arg.FullPath),
+                });
+            }
+        }
+
+        internal void HandleEvents()
+        {
+            lock (_QueuedEvents)
+            {
+                if (_QueuedEvents.Count <= 0)
+                    return;
+
+                _HandledEventInFrame.Clear();
+                while (_QueuedEvents.TryDequeue(out var arg))
+                {
+                    if (_HandledEventInFrame.Contains(arg))
+                    {
+                        continue;
+                    }
+
+                    if (RetryOnLocked && (arg.Type != FileEventType.Deleted && arg.IsFileLocked()))
+                    {
+                        _RetryQueue.Enqueue(arg);
+                        continue;
+                    }
+
+                    switch (arg.Type)
+                    {
+                        case FileEventType.Created: OnCreated?.Invoke(arg); break;
+                        case FileEventType.Deleted: OnDeleted?.Invoke(arg); break;
+                        case FileEventType.Renamed: OnRenamed?.Invoke((FileRenamedEventArgs)arg); break;
+                        case FileEventType.Changed: OnChanged?.Invoke(arg); break;
+                    }
+
+                    _HandledEventInFrame.Add(arg);
+                }
+
+                while (_RetryQueue.TryDequeue(out var arg))
+                {
+                    _QueuedEvents.Enqueue(arg);
+                }
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_DisposedValue)
+            {
+                if (disposing)
+                {
+                    _Watcher.Dispose();
+                    OnCreated = null;
+                    OnDeleted = null;
+                    OnRenamed = null;
+                    OnChanged = null;
+
+                    _QueuedEvents.Clear();
+                    _HandledEventInFrame.Clear();
+                    _RetryQueue.Clear();
+                    SafeFileSystemWatcherUpdater_Impl.RemoveWatcher(this);
+                }
+                _DisposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/GTFO-API/Utilities/SafeFileSystemWatcher.cs
+++ b/GTFO-API/Utilities/SafeFileSystemWatcher.cs
@@ -239,6 +239,7 @@ public sealed class SafeFileSystemWatcher : IDisposable
         }
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         Dispose(disposing: true);


### PR DESCRIPTION
## Add `SafeFileSystemWatcher` for providing full alternative to `LiveEdit`
### Feature:
- Improved Event Storm Handling vs `LiveEdit` (Uses HashSet Instead of Timer based debouncing)
- Improved Lock Handling vs `LiveEdit` (Uses Requeue Instead of Finite Retry by Coroutine)
- Shorthand method for `ConfigFile` Watching

### Example:
```cs
// Create FSW from ConfigFile
var watcher = SafeFileSystemWatcher.Create(cfg);
Intensity = cfg.Bind(/*Blah*/);
Intensity.SettingChanged += SettingChanged;
cfg.ConfigReloaded += ConfigReloaded;
```

```cs
var watcher = SafeFileSystemWatcher.Create(gameDataPath, filters: ["*.json", "*.jsonc"], includeSubDir: true);
watcher.OnChanged += OnChanged;
watcher.OnDeleted += OnDeleted;
watcher.OnCreated += OnCreated;
watcher.OnRenamed += OnRenamed;

//

watcher.Dispose();
```