### PR TITLE
Add OnCheckpointReached and OnCheckpointReloaded events

### DIFF
--- a/GTFO-API/API/EventAPI.cs
+++ b/GTFO-API/API/EventAPI.cs
@@ -64,6 +64,15 @@ namespace GTFO.API
         /// </summary>
         public static event FocusStateChangedDelegate OnFocusStateChanged;
 
+        /// <summary>
+        /// Invoked when a checkpoint is reached
+        /// </summary>
+        public static event Action OnCheckpointReached;
+
+        /// <summary>
+        /// Invoked when a checkpoint is reloaded
+        /// </summary>
+        public static event Action OnCheckpointReloaded;
 
         private static bool _InitialSceneLoaded = false;
 
@@ -97,5 +106,9 @@ namespace GTFO.API
             APILogger.Verbose(nameof(EventAPI), $"{nameof(OnFocusStateChanged)} Invoked ({oldState} -> {newState})");
             SafeInvoke.InvokeDelegate<FocusStateChangedDelegate>(OnFocusStateChanged, (del) => { del(oldState, newState); });
         }
+
+        internal static void CheckpointReached() => SafeInvoke.Invoke(OnCheckpointReached);
+
+        internal static void CheckpointReloaded() => SafeInvoke.Invoke(OnCheckpointReloaded);
     }
 }

--- a/GTFO-API/Patches/CheckpointManager_Patches.cs
+++ b/GTFO-API/Patches/CheckpointManager_Patches.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+
+namespace GTFO.API.Patches;
+
+[HarmonyPatch(typeof(CheckpointManager))]
+internal static class CheckpointManager_Patches
+{
+    [HarmonyPatch(nameof(CheckpointManager.OnStateChange))]
+    [HarmonyWrapSafe]
+    [HarmonyPostfix]
+    static void Pre_StateChanged(pCheckpointState oldState, pCheckpointState newState, bool isRecall)
+    {
+        if (!oldState.isReloadingCheckpoint && !newState.isReloadingCheckpoint)
+        {
+            // Ignore cases:
+            // Client syncs on drop with isRecall: true.
+            // Client runs a redundant StoreCheckpoint call w/ no changes prior to any change.
+            if (isRecall || oldState.doorLockPosition == newState.doorLockPosition)
+                return;
+
+            EventAPI.CheckpointReached();
+        }
+        else if (oldState.isReloadingCheckpoint && isRecall)
+        {
+            EventAPI.CheckpointReloaded();
+        }
+    }
+}


### PR DESCRIPTION
Tested the patterns (+ deeper combinations with identical behavior), mainly with CConsole checkpoint but with one door checkpoint test:

Host:
- Checkpoint -> Checkpoint
- Checkpoint -> Reload -> Checkpoint
- Checkpoint -> Reload -> Reload

Client:
- Checkpoint -> Checkpoint -> Reload -> Checkpoint -> Checkpoint
- Join-in-progress

Checkpoints at an identical door location don't appear to work, at least using CConsole Checkpoint command, so that shouldn't be a concern for the client case - although there would be no way to separate the false positives if that were a concern anyway.